### PR TITLE
Fix bug in MO non-dominated sorting

### DIFF
--- a/R/nds_selection.R
+++ b/R/nds_selection.R
@@ -73,8 +73,12 @@ nds_selection = function(points, n_select, ref_point = NULL, minimize = TRUE) {
 
     # index of the tied case with the lowest hypervolume contribution
     to_remove = which(hypervolumes == max(hypervolumes))
-    # sample the index as tie breaker
-    to_remove = sample(to_remove, 1)
+    
+    if (length(to_remove) > 1) {
+      # sample the index as tie breaker
+      to_remove = sample(to_remove, size = 1)       
+    }
+
     tie_points = tie_points[, -to_remove, drop = FALSE]
     tie_surv = tie_surv[-to_remove]
   }


### PR DESCRIPTION
Problem: `sample(to_remove, 1)` is equivalent to `sample(1:to_remove, 1)` for `to_remove` being a integer vector of length one; this is  not what we want at this place (in case `to_remove` happens to be a vector of length one). 