### PR TITLE
refactor: replace pima task with sonar

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -94,7 +94,7 @@ We use the `tune()` function to run the optimization.
 ```{r}
 instance = tune(
   tnr("hyperband", eta = 3),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = learner,
   resampling = rsmp("cv", folds = 3),
   measures = msr("classif.ce")

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We use the `tune()` function to run the optimization.
 ``` r
 instance = tune(
   tnr("hyperband", eta = 3),
-  task = tsk("pima"),
+  task = tsk("sonar"),
   learner = learner,
   resampling = rsmp("cv", folds = 3),
   measures = msr("classif.ce")

--- a/man-roxygen/example_tuner.R
+++ b/man-roxygen/example_tuner.R
@@ -10,10 +10,10 @@
 #'   )
 #'
 #'   \donttest{
-#'   # hyperparameter tuning on the pima indians diabetes data set
+#'   # hyperparameter tuning on the sonar data set
 #'   instance = tune(
 #'     tnr("<%= id %>"),
-#'     task = tsk("pima"),
+#'     task = tsk("sonar"),
 #'     learner = lrn("classif.xgboost", eval_metric = "logloss"),
 #'     resampling = rsmp("cv", folds = 3),
 #'     measures = msr("classif.ce"),

--- a/man/mlr_tuners_hyperband.Rd
+++ b/man/mlr_tuners_hyperband.Rd
@@ -156,10 +156,10 @@ if(requireNamespace("xgboost")) {
   )
 
   \donttest{
-  # hyperparameter tuning on the pima indians diabetes data set
+  # hyperparameter tuning on the sonar data set
   instance = tune(
     tnr("hyperband"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.xgboost", eval_metric = "logloss"),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/man/mlr_tuners_successive_halving.Rd
+++ b/man/mlr_tuners_successive_halving.Rd
@@ -147,10 +147,10 @@ if(requireNamespace("xgboost")) {
   )
 
   \donttest{
-  # hyperparameter tuning on the pima indians diabetes data set
+  # hyperparameter tuning on the sonar data set
   instance = tune(
     tnr("successive_halving"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = lrn("classif.xgboost", eval_metric = "logloss"),
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -27,7 +27,7 @@ test_tuner_hyperband = function(eta, learner, measures = msr("classif.ce"), samp
 
   instance = tune(
     tnr("hyperband", eta = eta, sampler = sampler),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     measures = measures,
     resampling = rsmp("holdout"),
@@ -68,7 +68,7 @@ test_tuner_successive_halving = function(
 
   instance = tune(
     tnr("successive_halving", n = n, eta = eta, sampler = sampler, adjust_minimum_budget = adjust_minimum_budget),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     measures = measures,
     resampling = rsmp("holdout")
@@ -107,7 +107,7 @@ test_tuner_asha = function(
 
   instance = tune(
     tnr("async_successive_halving", eta = eta, sampler = sampler),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     measures = measures,
     resampling = rsmp("cv", folds = 5),

--- a/tests/testthat/test_TunerAsyncSuccessiveHalving.R
+++ b/tests/testthat/test_TunerAsyncSuccessiveHalving.R
@@ -158,7 +158,7 @@ test_that("TunerAsyncSuccessiveHalving errors if not enough parameters are sampl
   expect_error(
     tune(
       tnr("async_successive_halving", sampler = sampler),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce"),
@@ -191,7 +191,7 @@ test_that("TunerAsyncSuccessiveHalving errors if budget parameter is sampled", {
   expect_error(
     tune(
       tnr("async_successive_halving", sampler = sampler),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce"),
@@ -218,7 +218,7 @@ test_that("TunerAsyncSuccessiveHalving errors if budget parameter is not numeric
   expect_error(
     tune(
       tnr("async_successive_halving"),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce"),
@@ -245,7 +245,7 @@ test_that("TunerAsyncSuccessiveHalving errors if multiple budget parameters are 
   expect_error(
     tune(
       tnr("async_successive_halving"),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerBatchHyperband.R
+++ b/tests/testthat/test_TunerBatchHyperband.R
@@ -80,7 +80,7 @@ test_that("TunerBatchHyperband errors if not enough parameters are sampled", {
   expect_error(
     tune(
       tnr("hyperband", sampler = sampler),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce")
@@ -106,7 +106,7 @@ test_that("TunerBatchHyperband errors if budget parameter is sampled", {
   expect_error(
     tune(
       tnr("hyperband", sampler = sampler),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce")
@@ -126,7 +126,7 @@ test_that("TunerBatchHyperband errors if budget parameter is not numeric", {
   expect_error(
     tune(
       tnr("hyperband"),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce")
@@ -146,7 +146,7 @@ test_that("TunerBatchHyperband errors if multiple budget parameters are set", {
   expect_error(
     tune(
       tnr("hyperband"),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce")
@@ -187,7 +187,7 @@ test_that("TunerBatchHyperband works with repetitions", {
 
   instance = tune(
     tnr("hyperband", repetitions = 2),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce")
@@ -201,7 +201,7 @@ test_that("TunerBatchHyperband terminates itself", {
 
   instance = tune(
     tnr("hyperband"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce")
@@ -215,7 +215,7 @@ test_that("TunerBatchHyperband works with infinite repetitions", {
 
   instance = tune(
     tnr("hyperband", repetitions = Inf),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),

--- a/tests/testthat/test_TunerBatchSuccessiveHalving.R
+++ b/tests/testthat/test_TunerBatchSuccessiveHalving.R
@@ -90,7 +90,7 @@ test_that("TunerBatchSuccessiveHalving errors if not enough parameters are sampl
   expect_error(
     tune(
       tnr("successive_halving", sampler = sampler),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce")
@@ -116,7 +116,7 @@ test_that("TunerBatchSuccessiveHalving errors if budget parameter is sampled", {
   expect_error(
     tune(
       tnr("successive_halving", sampler = sampler),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce")
@@ -136,7 +136,7 @@ test_that("TunerBatchSuccessiveHalving errors if budget parameter is not numeric
   expect_error(
     tune(
       tnr("successive_halving"),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce")
@@ -156,7 +156,7 @@ test_that("TunerBatchSuccessiveHalving errors if multiple budget parameters are 
   expect_error(
     tune(
       tnr("successive_halving"),
-      task = tsk("pima"),
+      task = tsk("sonar"),
       learner = learner,
       resampling = rsmp("cv", folds = 3),
       measures = msr("classif.ce")
@@ -201,7 +201,7 @@ test_that("TunerBatchSuccessiveHalving works with repetitions", {
 
   instance = tune(
     tnr("successive_halving", repetitions = 2),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce")
@@ -215,7 +215,7 @@ test_that("TunerBatchSuccessiveHalving terminates itself", {
 
   instance = tune(
     tnr("successive_halving"),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce")
@@ -229,7 +229,7 @@ test_that("TunerBatchSuccessiveHalving works with infinite repetitions", {
 
   instance = tune(
     tnr("successive_halving", repetitions = Inf),
-    task = tsk("pima"),
+    task = tsk("sonar"),
     learner = learner,
     resampling = rsmp("cv", folds = 3),
     measures = msr("classif.ce"),


### PR DESCRIPTION
## Why

The `pima` task is being removed from mlr3 because the `PimaIndiansDiabetes2` dataset was removed from the `mlbench` package. Any downstream code relying on `tsk("pima")` will break once that removal lands.

## What

Replaces every usage of `tsk("pima")` with `tsk("sonar")`, another binary classification task. Sonar (208 rows, 60 numeric features `V1..V60`, target `Class`, positive `M`) has **no missing values**, and none of the affected tests or examples depend on pima-specific properties (feature count, columns, row count, positive class) — the tasks are only used as generic classification tasks to drive multi-fidelity tuning, where the budget lives on learner hyperparameters.

This also makes the README internally consistent: its prose and final `learner$train(tsk("sonar"))` call already referenced sonar, while only the tuning `tune()` call still used pima.

## Files changed

- `tests/testthat/helper.R`, `test_TunerBatchHyperband.R`, `test_TunerBatchSuccessiveHalving.R`, `test_TunerAsyncSuccessiveHalving.R`
- `man-roxygen/example_tuner.R` (roxygen source) plus regenerated `man/mlr_tuners_hyperband.Rd` and `man/mlr_tuners_successive_halving.Rd`
- `README.Rmd` and `README.md`

## Testing

`devtools::test()` batch tuner tests (`TunerBatchHyperband`, `TunerBatchSuccessiveHalving`) pass. Async tests skip (guarded, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)